### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,7 +27,7 @@ func (c *Context) SetLogger(logger *logrus.Logger) {
 	c.logger = logger
 }
 
-// Returns a Logrus logger instance
+// GetLogger returns a Logrus logger instance
 func (c *Context) GetLogger() *logrus.Logger {
 	return c.logger
 }
@@ -38,7 +38,7 @@ func (c *Context) SetRequest(req *http.Request) {
 	c.request = &request
 }
 
-// Returns a HTTP request component instance
+// GetRequest returns a HTTP request component instance
 func (c *Context) GetRequest() *Request {
 	return c.request
 }
@@ -48,7 +48,7 @@ func (c *Context) SetRoute(route *Route) {
 	c.route = route
 }
 
-// Returns a route instance
+// GetRoute returns a route instance
 func (c *Context) GetRoute() *Route {
 	return c.route
 }
@@ -61,12 +61,12 @@ func (c *Context) SetResponse(res http.ResponseWriter) {
 	c.AddDefaultHeaders()
 }
 
-// Returns a HTTP response component instance
+// GetResponse returns a HTTP response component instance
 func (c *Context) GetResponse() *Response {
 	return c.response
 }
 
-// Adds some defaults headers to send with the response
+// AddDefaultHeaders adds some defaults headers to send with the response
 func (c *Context) AddDefaultHeaders() {
 	request := c.GetRequest()
 	response := c.GetResponse()

--- a/gofast.go
+++ b/gofast.go
@@ -93,7 +93,7 @@ func (g *Gofast) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	g.HandleRoute(res, req, matchedRoute)
 }
 
-// Handles a route with the initialized context
+// HandleRoute handles a route with the initialized context
 func (g *Gofast) HandleRoute(res http.ResponseWriter, req *http.Request, route Route) {
 	startTime := time.Now()
 

--- a/middleware.go
+++ b/middleware.go
@@ -15,12 +15,12 @@ func NewMiddleware() Middleware {
 	return Middleware{middlewares: make([]MiddlewareFunc, 0)}
 }
 
-// Adds a new middleware
+// Use adds a new middleware
 func (m *Middleware) Use(middleware MiddlewareFunc) {
 	m.middlewares = append(m.middlewares, middleware)
 }
 
-// Handle middlewares and returns handler
+// HandleMiddlewares handles middlewares and returns handler
 func (m *Middleware) HandleMiddlewares(context Context) Handler {
 	m.Use(func(context Context, next MiddlewareFunc) Handler {
 		return context.GetRoute().GetHandler()

--- a/request.go
+++ b/request.go
@@ -30,12 +30,12 @@ func (r *Request) GetHttpRequest() *http.Request {
 	return r.httpRequest
 }
 
-// Adds a request parameter
+// AddParameter adds a request parameter
 func (r *Request) AddParameter(name string, value interface{}) {
 	r.parameters = append(r.parameters, Parameter{name, value})
 }
 
-// Returns a request parameter from given name
+// GetParameter returns a request parameter from given name
 func (r *Request) GetParameter(name string) interface{} {
 	var result interface{}
 
@@ -48,12 +48,12 @@ func (r *Request) GetParameter(name string) interface{} {
 	return result
 }
 
-// Returns a POST form value from given name
+// GetFormValue returns a POST form value from given name
 func (r *Request) GetFormValue(name string) interface{} {
 	return r.httpRequest.FormValue(name)
 }
 
-// Returns a request header from its name
+// GetHeader returns a request header from its name
 func (r *Request) GetHeader(name string) string {
 	return r.GetHttpRequest().Header.Get(name)
 }

--- a/response.go
+++ b/response.go
@@ -24,7 +24,7 @@ func (r *Response) SetStatusCode(statusCode int) {
 	r.statusCode = statusCode
 }
 
-// Returns Response status code
+// GetStatusCode returns Response status code
 func (r *Response) GetStatusCode() int {
 	return r.statusCode
 }

--- a/router.go
+++ b/router.go
@@ -28,7 +28,7 @@ func NewRouter() Router {
 	return Router{routes: make([]Route, 0)}
 }
 
-// Adds different HTTP methods route
+// Get adds different HTTP methods route
 func (r *Router) Get(name string, pattern string, handler Handler) {
 	r.Add("GET", name, pattern, handler)
 }
@@ -61,18 +61,18 @@ func (r *Router) All(name string, pattern string, handler Handler) {
 	r.Add("*", name, pattern, handler)
 }
 
-// Adds a new route to router
+// Add adds a new route to router
 func (r *Router) Add(method string, name string, pattern string, handler Handler) {
 	route := Route{method, name, regexp.MustCompile(pattern), handler}
 	r.routes = append(r.routes, route)
 }
 
-// Returns all routes available in router
+// GetRoutes returns all routes available in router
 func (r *Router) GetRoutes() []Route {
 	return r.routes
 }
 
-// Returns a Route from given name
+// GetRoute returns a Route from given name
 func (r *Router) GetRoute(name string) Route {
 	var result Route
 
@@ -90,12 +90,12 @@ func (r *Router) SetFallback(handler Handler) {
 	r.Add("*", "fallback", "/", handler)
 }
 
-// Returns fallback route (for 404 error pages)
+// GetFallback returns fallback route (for 404 error pages)
 func (r *Router) GetFallback() Route {
 	return r.GetRoute("fallback")
 }
 
-// Returns a route pattern
+// GetPattern returns a route pattern
 func (r *Route) GetPattern() *regexp.Regexp {
 	return r.pattern
 }
@@ -105,7 +105,7 @@ func (r *Route) SetHandler(handler Handler) {
 	r.handler = handler
 }
 
-// Returns a route handler
+// GetHandler returns a route handler
 func (r *Route) GetHandler() Handler {
 	return r.handler
 }

--- a/templating.go
+++ b/templating.go
@@ -34,7 +34,7 @@ func (t *Templating) SetViewsDirectory(name string) {
 	t.viewsDirectory = name
 }
 
-// Returns templating views directory
+// GetViewsDirectory returns templating views directory
 func (t *Templating) GetViewsDirectory() string {
 	return t.viewsDirectory
 }
@@ -51,12 +51,12 @@ func (t *Templating) SetAssetsDirectory(name string) {
 	t.assetsDirectory = name
 }
 
-// Returns templating assets directory
+// GetAssetsDirectory returns templating assets directory
 func (t *Templating) GetAssetsDirectory() string {
 	return t.assetsDirectory
 }
 
-// Renders a template
+// Render renders a template
 func (t *Templating) Render(context Context, name string) {
 	var filename = fmt.Sprintf("%s/%s", t.GetViewsDirectory(), name)
 


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?